### PR TITLE
replaced script with entry point in setup.py

### DIFF
--- a/bin/pyicontract-lint
+++ b/bin/pyicontract-lint
@@ -1,7 +1,0 @@
-#!/usr/bin/env python3
-"""Lint contracts defined with icontract library."""
-
-import icontract_lint.main
-
-if __name__ == "__main__":
-    icontract_lint.main.main()

--- a/icontract_lint/main.py
+++ b/icontract_lint/main.py
@@ -60,7 +60,7 @@ def _main(args: Args, stream: TextIO) -> int:
     return 0
 
 
-def main() -> None:
+def main() -> int:
     """Wrap the main routine so that it can be tested."""
     args = parse_args(sys_argv=sys.argv)
-    sys.exit(_main(args=args, stream=sys.stdout))
+    return _main(args=args, stream=sys.stdout)

--- a/precommit.py
+++ b/precommit.py
@@ -28,26 +28,26 @@ def main() -> int:
     if overwrite:
         subprocess.check_call(
             [
-                "yapf", "--in-place", "--style=style.yapf", "--recursive", "tests", "icontract_lint",
-                "bin/pyicontract-lint", "setup.py", "precommit.py"
+                "yapf", "--in-place", "--style=style.yapf", "--recursive", "tests", "icontract_lint", "setup.py",
+                "precommit.py"
             ],
             cwd=repo_root.as_posix())
     else:
         subprocess.check_call(
             [
-                "yapf", "--diff", "--style=style.yapf", "--recursive", "tests", "icontract_lint",
-                "bin/pyicontract-lint", "setup.py", "precommit.py"
+                "yapf", "--diff", "--style=style.yapf", "--recursive", "tests", "icontract_lint", "setup.py",
+                "precommit.py"
             ],
             cwd=repo_root.as_posix())
 
     print("Mypy'ing...")
-    subprocess.check_call(["mypy", "icontract_lint", "bin/pyicontract-lint", "tests"], cwd=repo_root.as_posix())
+    subprocess.check_call(["mypy", "icontract_lint", "tests"], cwd=repo_root.as_posix())
 
     print("Pylint'ing...")
     subprocess.check_call(["pylint", "--rcfile=pylint.rc", "tests", "icontract_lint"], cwd=repo_root.as_posix())
 
     print("Pydocstyle'ing...")
-    subprocess.check_call(["pydocstyle", "icontract_lint", "bin/pyicontract-lint"], cwd=repo_root.as_posix())
+    subprocess.check_call(["pydocstyle", "icontract_lint"], cwd=repo_root.as_posix())
 
     print("Testing...")
     env = os.environ.copy()

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,9 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6'
+        'Programming Language :: Python :: 3.6',
+        'Operating System :: Microsoft :: Windows',
+        'Operating System :: POSIX'
         # yapf: enable
     ],
     license='License :: OSI Approved :: MIT License',
@@ -51,7 +53,7 @@ setup(
             # yapf: enable
         ],
     },
-    scripts=['bin/pyicontract-lint'],
+    entry_points={"console_scripts": ["pyicontract-lint = icontract_lint.main:main"]},
     py_modules=['icontract_lint', 'pyicontract_lint_meta'],
     include_package_data=True,
     package_data={


### PR DESCRIPTION
The `setup.py` specified previously a script which caused problems when
running pyicontract-lint on Windows (*e.g.*, Windows could not find the
interpreter since the shebang is ignored). This change removes the
script and specifies an entry point in `setup.py` so that the executable
is correctly created on Windows upon installation.

Fixes #15.

See also:
https://setuptools.readthedocs.io/en/latest/setuptools.html#automatic-script-creation