### PR TITLE
upgraded pylint to 2.6.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
         'dev': [
             # yapf: disable
             'mypy==0.620',
-            'pylint==2.1.1',
+            'pylint==2.6.0',
             'yapf==0.20.2',
             'tox>=3.0.0',
             'pydocstyle>=2.1.1,<3',


### PR DESCRIPTION
The pylint had to be updated to 2.6.0 since its dependencies
got broken (such as isort).

See also:
https://github.com/timothycrosley/isort/issues/1273
https://github.com/conda-forge/pylint-feedstock/issues/29