### PR TITLE
upgraded mypy to 0.782

### DIFF
--- a/icontract_lint/__init__.py
+++ b/icontract_lint/__init__.py
@@ -496,12 +496,14 @@ def check_file(path: pathlib.Path) -> List[Error]:
         cause = err.__cause__
         assert isinstance(cause, SyntaxError)
 
+        lineno = -1 if cause.lineno is None else cause.lineno  # pylint: disable=no-member
+
         return [
             Error(
                 identifier=ErrorID.INVALID_SYNTAX,
                 description=cause.msg,  # pylint: disable=no-member
                 filename=path.as_posix(),
-                lineno=cause.lineno)  # pylint: disable=no-member
+                lineno=lineno)  # pylint: disable=no-member
         ]
 
     lint_visitor = _LintVisitor(filename=path.as_posix())

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
     extras_require={
         'dev': [
             # yapf: disable
-            'mypy==0.620',
+            'mypy==0.782',
             'pylint==2.6.0',
             'yapf==0.20.2',
             'tox>=3.0.0',


### PR DESCRIPTION
This upgraded mypy version detects additional issues which were
ignored in the previous versions.

Additionally, mypy 0.782 is compatible with Python 3.8 (which we want to
support eventually).