### PR TITLE
handled paths platform-depedentent

### DIFF
--- a/icontract_lint/__init__.py
+++ b/icontract_lint/__init__.py
@@ -486,12 +486,12 @@ def check_file(path: pathlib.Path) -> List[Error]:
             return []
 
     try:
-        modname = ".".join(astroid.modutils.modpath_from_file(filename=path.as_posix()))
+        modname = ".".join(astroid.modutils.modpath_from_file(filename=str(path)))
     except ImportError:
         modname = '<unknown module>'
 
     try:
-        tree = astroid.parse(code=text, module_name=modname, path=path.as_posix())
+        tree = astroid.parse(code=text, module_name=modname, path=str(path))
     except astroid.exceptions.AstroidSyntaxError as err:
         cause = err.__cause__
         assert isinstance(cause, SyntaxError)
@@ -502,11 +502,11 @@ def check_file(path: pathlib.Path) -> List[Error]:
             Error(
                 identifier=ErrorID.INVALID_SYNTAX,
                 description=cause.msg,  # pylint: disable=no-member
-                filename=path.as_posix(),
+                filename=str(path),
                 lineno=lineno)  # pylint: disable=no-member
         ]
 
-    lint_visitor = _LintVisitor(filename=path.as_posix())
+    lint_visitor = _LintVisitor(filename=str(path))
     lint_visitor.visit(node=tree)
 
     return lint_visitor.errors

--- a/setup.py
+++ b/setup.py
@@ -50,8 +50,7 @@ setup(
             'yapf==0.20.2',
             'tox>=3.0.0',
             'pydocstyle>=2.1.1,<3',
-            'coverage>=4.5.1,<5',
-            'temppathlib>=1.0.3,<2'
+            'coverage>=4.5.1,<5'
             # yapf: enable
         ],
     },


### PR DESCRIPTION
We erroneously assumed the platform to be POSIX. Consequently, the paths
and temporary files were not handled properly (*e.g.*, `as_posix()` was
used, `NamedTemporaryFile` was re-opened, the default interpreter was
assumed to be `python3` *etc*.).

This change fixes all these issues and the precommit checks run
successfully on Windows.