### PR TITLE
made graceful read and parse failures

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,6 +27,8 @@ The following checks are performed:
 +---------------------------------------------------------------------------------------+----------------------+
 | Description                                                                           | Identifier           |
 +=======================================================================================+======================+
+| File should be read and decoded correctly.                                            | unreadable           |
++---------------------------------------------------------------------------------------+----------------------+
 | A preconditions expects a subset of function's arguments.                             | pre-invalid-arg      |
 +---------------------------------------------------------------------------------------+----------------------+
 | A snapshot expects at most an argument element of the function's arguments.           | snapshot-invalid-arg |


### PR DESCRIPTION
Running pyicontract-lint against the repository [telereddit][1] made
it fail with an exception. This change handles most of the failures
gracefully returning a human-readable error message with extra
information.

This is related to #21.

[1]: https://github.com/fabiosangregorio/telereddit