### PR TITLE
fixed to ignore inference error in decorators

### DIFF
--- a/icontract_lint/__init__.py
+++ b/icontract_lint/__init__.py
@@ -351,25 +351,6 @@ class _LintVisitor(_AstroidVisitor):
         else:
             raise NotImplementedError("Unhandled pytype: {}".format(pytype))
 
-    def _infer_decorator(self, node: astroid.nodes.Call) -> Optional[astroid.bases.Instance]:
-        """
-        Try to infer the decorator as instance of a class.
-
-        :param node: decorator AST node
-        :return: instance of the decorator or None if decorator instance could not be inferred
-        """
-        # While this function does not use ``self``, keep it close to the usage to improve the readability.
-        # pylint: disable=no-self-use
-        try:
-            decorator = next(node.infer())
-        except astroid.exceptions.NameInferenceError:
-            return None
-
-        if decorator is astroid.Uninferable:
-            return None
-
-        return decorator
-
     def visit_FunctionDef(self, node: astroid.nodes.FunctionDef) -> None:  # pylint: disable=invalid-name
         """Lint the function definition."""
         if node.decorators is None:
@@ -394,7 +375,25 @@ class _LintVisitor(_AstroidVisitor):
                 pass
 
         # Infer the decorator instances
-        decorators = [self._infer_decorator(node=decorator_node) for decorator_node in node.decorators.nodes]
+
+        def infer_decorator(a_node: astroid.nodes.Call) -> Optional[astroid.bases.Instance]:
+            """
+            Try to infer the decorator as instance of a class.
+
+            :param a_node: decorator AST node
+            :return: instance of the decorator or None if decorator instance could not be inferred
+            """
+            try:
+                decorator = next(a_node.infer())
+            except (astroid.exceptions.NameInferenceError, astroid.exceptions.InferenceError):
+                return None
+
+            if decorator is astroid.Uninferable:
+                return None
+
+            return decorator
+
+        decorators = [infer_decorator(a_node=decorator_node) for decorator_node in node.decorators.nodes]
 
         # Check the decorators individually
         for decorator, decorator_node in zip(decorators, node.decorators.nodes):

--- a/tests/test_icontract_lint.py
+++ b/tests/test_icontract_lint.py
@@ -82,6 +82,46 @@ class TestCheckUnreadableFile(unittest.TestCase):
             self.assertEqual(str(pth), errors[0].filename)
 
 
+class TestUninferrableDecorator(unittest.TestCase):
+    def test_astroid_name_inference_error(self):
+        text = textwrap.dedent("""\
+                @some_uninferrable_decorator
+                def some_func(x: int) -> int:
+                    pass
+                """)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = pathlib.Path(tmp)
+            pth = tmp_path / "some_module.py"
+            pth.write_text(text)
+
+            with sys_path_with(tmp_path):
+                errors = icontract_lint.check_file(path=pth)
+                self.assertListEqual([], errors)
+
+    def test_astroid_inferrence_error(self):
+        # This example was adapted from the issue https://github.com/Parquery/pyicontract-lint/issues/27.
+        text = textwrap.dedent("""\
+                class RuleTable:
+                    @classinstancemethod
+                    def insert_rule(cls, index, rule_):
+                        pass
+        
+                    @insert_rule.instancemethod
+                    def insert_rule(self, index, rule_):
+                        pass
+                """)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = pathlib.Path(tmp)
+            pth = tmp_path / "some_module.py"
+            pth.write_text(text)
+
+            with sys_path_with(tmp_path):
+                errors = icontract_lint.check_file(path=pth)
+                self.assertListEqual([], errors)
+
+
 class TestCheckFile(unittest.TestCase):
     def test_wo_contracts(self):
         text = textwrap.dedent("""\
@@ -99,23 +139,6 @@ class TestCheckFile(unittest.TestCase):
                     @staticmethod
                     def some_static_method(self, x: int) -> int:
                         pass
-                """)
-
-        with tempfile.TemporaryDirectory() as tmp:
-            tmp_path = pathlib.Path(tmp)
-            pth = tmp_path / "some_module.py"
-            pth.write_text(text)
-
-            with sys_path_with(tmp_path):
-                errors = icontract_lint.check_file(path=pth)
-
-                self.assertListEqual([], errors)
-
-    def test_uninferrable_decorator(self):
-        text = textwrap.dedent("""\
-                @some_uninferrable_decorator
-                def some_func(x: int) -> int:
-                    pass
                 """)
 
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
Astroid has a hard time inferring decorators when they are defined
somewhat recursively. Since we only care about *icontract* decorators,
we ignore all the uninferrable decorators.

This might cause certain yet-to-be-discovered edge cases with icontract
decorators being ignored, though that is very unlikely.

Fixes #27.