### PR TITLE
released 2.1.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,10 @@
+2.1.1
+=====
+* Started ignoring Astroid inference errors in decorators.
+
+  This is critical so that files can be processed even though Astroid
+  fails to correctly infer all the decorators.
+
 2.1.0
 =====
 * Made handling of paths platform-dependent

--- a/pyicontract_lint_meta.py
+++ b/pyicontract_lint_meta.py
@@ -3,7 +3,7 @@
 __title__ = 'pyicontract-lint'
 __description__ = 'Lint contracts defined with icontract library.'
 __url__ = 'https://github.com/Parquery/pyicontract-lint'
-__version__ = '2.1.0'
+__version__ = '2.1.1'
 __author__ = 'Marko Ristin'
 __author_email__ = 'marko.ristin@gmail.com'
 __license__ = 'MIT'


### PR DESCRIPTION
* Started ignoring Astroid inference errors in decorators.

  This is critical so that files can be processed even though Astroid
  fails to correctly infer all the decorators.