### PR TITLE
Refactored unit tests

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -1,0 +1,19 @@
+"""Provide common functionality for the tests."""
+import pathlib
+import sys
+
+
+class sys_path_with:  # pylint: disable=invalid-name
+    """Add the path to the sys.path in the context."""
+
+    def __init__(self, path: pathlib.Path) -> None:
+        """Set property with the given argument."""
+        self.path = path
+
+    def __enter__(self):
+        """Add the path to the ``sys.path``."""
+        sys.path.insert(0, str(self.path))
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        """Remove the path from the ``sys.path``."""
+        sys.path.remove(str(self.path))

--- a/tests/test_invariant.py
+++ b/tests/test_invariant.py
@@ -1,0 +1,104 @@
+# pylint: disable=missing-docstring
+import pathlib
+import tempfile
+import textwrap
+import unittest
+
+import icontract_lint
+import tests.common
+
+
+class TestInvariant(unittest.TestCase):
+    def test_valid(self):
+        text = textwrap.dedent("""\
+            from icontract import invariant
+
+            def lt_100(self) -> bool:
+                return self.x < 100
+
+            @invariant(lambda self: self.x > 0)
+            @invariant(condition=lambda self: self.x % 2 == 0)
+            @invariant(lt_100)
+            class SomeClass:
+                def __init__(self) -> None:
+                    self.x = 22
+            """)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = pathlib.Path(tmp)
+
+            pth = tmp_path / "some_module.py"
+            pth.write_text(text)
+
+            with tests.common.sys_path_with(tmp_path):
+                errors = icontract_lint.check_file(path=pth)
+                self.assertListEqual([], errors)
+
+    def test_invalid_arg(self):
+        text = textwrap.dedent("""\
+            from icontract import invariant
+
+            def lt_100(selfie) -> bool:
+                return selfie.x < 100
+
+            @invariant(lambda selfie: selfie.x > 0)
+            @invariant(condition=lambda selfie: selfie.x % 2 == 0)
+            @invariant(lt_100)
+            class SomeClass:
+                def __init__(self) -> None:
+                    self.x = 22
+            """)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = pathlib.Path(tmp)
+
+            pth = tmp_path / "some_module.py"
+            pth.write_text(text)
+
+            with tests.common.sys_path_with(tmp_path):
+                errors = icontract_lint.check_file(path=pth)
+                self.assertEqual(3, len(errors))
+
+                for err, lineno in zip(errors, [6, 7, 8]):
+                    # yapf: disable
+                    self.assertDictEqual({
+                        'identifier': 'inv-invalid-arg',
+                        'description': "An invariant expects one and only argument 'self', "
+                                       "but the arguments are: ['selfie']",
+                        'filename': str(pth),
+                        'lineno': lineno
+                    }, err.as_mapping())
+                    # yapf: enable
+
+    def test_no_condition(self):
+        text = textwrap.dedent("""\
+            from icontract import invariant
+
+            @invariant(description='hello')
+            class SomeClass:
+                def __init__(self) -> None:
+                    self.x = 22
+            """)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = pathlib.Path(tmp)
+
+            pth = tmp_path / "some_module.py"
+            pth.write_text(text)
+
+            with tests.common.sys_path_with(tmp_path):
+                errors = icontract_lint.check_file(path=pth)
+                self.assertEqual(1, len(errors))
+
+                err = errors[0]
+
+                self.assertDictEqual({
+                    'identifier': 'no-condition',
+                    'description': 'The contract decorator lacks the condition.',
+                    'filename': str(pth),
+                    'lineno': 3
+                }, err.as_mapping())
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_postcondition.py
+++ b/tests/test_postcondition.py
@@ -1,0 +1,234 @@
+# pylint: disable=missing-docstring
+import pathlib
+import tempfile
+import textwrap
+import unittest
+
+import icontract_lint
+import tests.common
+
+
+class TestPostcondition(unittest.TestCase):
+    def test_uninferrable_returns_are_ok(self):
+        text = textwrap.dedent("""\
+            from icontract import ensure
+
+            @ensure(lambda result: result > 0)
+            def some_func(x: int) -> SomeUninferrableClass:
+                return x
+            """)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = pathlib.Path(tmp)
+
+            pth = tmp_path / "some_module.py"
+            pth.write_text(text)
+
+            with tests.common.sys_path_with(tmp_path):
+                self.assertListEqual([], icontract_lint.check_file(path=pth))
+
+    def test_valid(self):
+        text = textwrap.dedent("""\
+            from icontract import ensure
+
+            def lt_100(result: int) -> bool: 
+                return result < 100
+
+            @ensure(lambda result: result > 0)
+            @ensure(condition=lambda result: result % 2 == 0)
+            @ensure(lt_100)
+            def some_func(x: int) -> int:
+                return x
+            """)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = pathlib.Path(tmp)
+
+            pth = tmp_path / "some_module.py"
+            pth.write_text(text)
+
+            with tests.common.sys_path_with(tmp_path):
+                self.assertListEqual([], icontract_lint.check_file(path=pth))
+
+    def test_valid_without_returns(self):
+        text = textwrap.dedent("""\
+            from icontract import ensure
+
+            def lt_100(result: int) -> bool: 
+                return result < 100
+
+            @ensure(lambda result: result > 0)
+            @ensure(condition=lambda result: result % 2 == 0)
+            @ensure(lt_100)
+            def some_func(x: int):
+                return x
+            """)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = pathlib.Path(tmp)
+
+            pth = tmp_path / "some_module.py"
+            pth.write_text(text)
+
+            with tests.common.sys_path_with(tmp_path):
+                self.assertListEqual([], icontract_lint.check_file(path=pth))
+
+    def test_result_none(self):
+        text = textwrap.dedent("""\
+            from icontract import ensure
+
+            def lt_100(result: int) -> bool: 
+                return result < 100
+
+            @ensure(lambda result: result > 0)
+            @ensure(condition=lambda result: result % 2 == 0)
+            @ensure(lt_100)
+            def some_func(x: int) -> None:
+                return x
+            """)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = pathlib.Path(tmp)
+
+            pth = tmp_path / "some_module.py"
+            pth.write_text(text)
+
+            with tests.common.sys_path_with(tmp_path):
+                errors = icontract_lint.check_file(path=pth)
+
+                self.assertEqual(3, len(errors))
+                for err, lineno in zip(errors, [6, 7, 8]):
+                    self.assertDictEqual(
+                        {
+                            'identifier': 'post-result-none',
+                            'description': 'Function is annotated to return None, but postcondition expects a result.',
+                            'filename': str(pth),
+                            'lineno': lineno
+                        }, err.as_mapping())
+
+    def test_invalid_args(self):
+        text = textwrap.dedent("""\
+            from icontract import ensure
+
+            def some_other_func(x: int, result: int) -> bool: 
+                return result * x < 1000
+
+            @ensure(lambda x, result: result > x)
+            @ensure(condition=lambda x, result: result % x == 0)
+            @ensure(some_other_func)
+            def some_func(y: int) -> int:
+                return y
+            """)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = pathlib.Path(tmp)
+
+            pth = tmp_path / "some_module.py"
+            pth.write_text(text)
+
+            with tests.common.sys_path_with(tmp_path):
+                errors = icontract_lint.check_file(path=pth)
+                self.assertEqual(3, len(errors))
+
+                for err, lineno in zip(errors, [6, 7, 8]):
+                    self.assertDictEqual(
+                        {
+                            'identifier': 'post-invalid-arg',
+                            'description': 'Postcondition argument(s) are missing in the function signature: x',
+                            'filename': str(pth),
+                            'lineno': lineno
+                        }, err.as_mapping())
+
+    def test_result_conflict(self):
+        text = textwrap.dedent("""\
+            from icontract import ensure
+
+            def some_other_func(x: int, result: int) -> bool: 
+                return result * x < 1000
+
+            @ensure(lambda x, result: result > x)
+            @ensure(condition=lambda x, result: result % x == 0)
+            @ensure(some_other_func)
+            def some_func(x: int, result: int) -> int:
+                return result
+            """)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = pathlib.Path(tmp)
+
+            pth = tmp_path / "some_module.py"
+            pth.write_text(text)
+
+            with tests.common.sys_path_with(tmp_path):
+                errors = icontract_lint.check_file(path=pth)
+                self.assertEqual(3, len(errors))
+
+                for err, lineno in zip(errors, [6, 7, 8]):
+                    self.assertDictEqual({
+                        'identifier': 'post-result-conflict',
+                        'description': "Function argument 'result' conflicts with the postcondition.",
+                        'filename': str(pth),
+                        'lineno': lineno
+                    }, err.as_mapping())
+
+    def test_old_conflict(self):
+        text = textwrap.dedent("""\
+            from typing import List
+
+            from icontract import ensure
+
+            @snapshot(lambda lst: lst[:])
+            @ensure(lambda OLD, lst, value: OLD.lst + [value] == lst)
+            def some_func(lst: List[int], value: int, OLD: int) -> int:  # OLD argument is conflicting
+                lst.append(value)
+                return value
+            """)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = pathlib.Path(tmp)
+
+            pth = tmp_path / "some_module.py"
+            pth.write_text(text)
+
+            with tests.common.sys_path_with(tmp_path):
+                errors = icontract_lint.check_file(path=pth)
+                self.assertEqual(1, len(errors))
+
+                for err, lineno in zip(errors, [6]):
+                    self.assertDictEqual({
+                        'identifier': 'post-old-conflict',
+                        'description': "Function argument 'OLD' conflicts with the postcondition.",
+                        'filename': str(pth),
+                        'lineno': lineno
+                    }, err.as_mapping())
+
+    def test_no_condition(self):
+        text = textwrap.dedent("""\
+            from icontract import ensure
+
+            @ensure(description="I am a contract without condition.")
+            def some_func(y: int) -> int:
+                return y
+            """)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = pathlib.Path(tmp)
+
+            pth = tmp_path / "some_module.py"
+            pth.write_text(text)
+
+            with tests.common.sys_path_with(tmp_path):
+                errors = icontract_lint.check_file(path=pth)
+
+                self.assertEqual(1, len(errors))
+
+                self.assertDictEqual({
+                    'identifier': 'no-condition',
+                    'description': 'The contract decorator lacks the condition.',
+                    'filename': str(pth),
+                    'lineno': 3
+                }, errors[0].as_mapping())
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_precondition.py
+++ b/tests/test_precondition.py
@@ -1,0 +1,105 @@
+# pylint: disable=missing-docstring
+import pathlib
+import tempfile
+import textwrap
+import unittest
+
+import icontract_lint
+import tests.common
+
+
+class TestPrecondition(unittest.TestCase):
+    def test_valid(self) -> None:
+        text = textwrap.dedent("""\
+            from icontract import require
+
+            def lt_100(x: int) -> bool: 
+                return x < 100
+
+            @require(lambda x: x > 0)
+            @require(condition=lambda x: x % 2 == 0)
+            @require(lt_100)
+            def some_func(x: int) -> int:
+                return x
+            """)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = pathlib.Path(tmp)
+
+            pth = tmp_path / "some_module.py"
+            pth.write_text(text)
+
+            with tests.common.sys_path_with(tmp_path):
+                errors = icontract_lint.check_file(path=pth)
+
+                self.assertListEqual([], errors)
+
+    def test_invalid_arg(self):
+        text = textwrap.dedent("""\
+            from icontract import require
+
+            def lt_100(x: int) -> bool: 
+                return x < 100
+
+            @require(lambda x: x > 0)
+            @require(condition=lambda x: x % 2 == 0)
+            @require(lt_100)
+            def some_func(y: int) -> int:
+                return y
+
+            class SomeClass:
+                @require(lambda x: x > 0)
+                def some_method(self, y: int) -> int:
+                    return y
+            """)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = pathlib.Path(tmp)
+
+            pth = tmp_path / "some_module.py"
+            pth.write_text(text)
+
+            with tests.common.sys_path_with(tmp_path):
+                errors = icontract_lint.check_file(path=pth)
+
+                self.assertEqual(4, len(errors))
+
+                for err, lineno in zip(errors, [6, 7, 8, 13]):
+                    self.assertDictEqual(
+                        {
+                            'identifier': 'pre-invalid-arg',
+                            'description': 'Precondition argument(s) are missing in the function signature: x',
+                            'filename': str(pth),
+                            'lineno': lineno
+                        }, err.as_mapping())
+
+    def test_no_condition(self):
+        text = textwrap.dedent("""\
+            from icontract import require
+
+            @require(description="I am a contract without condition.")
+            def some_func(y: int) -> int:
+                return y
+            """)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = pathlib.Path(tmp)
+
+            pth = tmp_path / "some_module.py"
+            pth.write_text(text)
+
+            with tests.common.sys_path_with(tmp_path):
+                errors = icontract_lint.check_file(path=pth)
+
+                self.assertEqual(1, len(errors))
+
+                self.assertDictEqual({
+                    'identifier': 'no-condition',
+                    'description': 'The contract decorator lacks the condition.',
+                    'filename': str(pth),
+                    'lineno': 3
+                }, errors[0].as_mapping())
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -1,0 +1,101 @@
+# pylint: disable=missing-docstring
+import pathlib
+import tempfile
+import textwrap
+import unittest
+
+import icontract_lint
+import tests.common
+
+
+class TestSnapshot(unittest.TestCase):
+    def test_valid(self):
+        text = textwrap.dedent("""\
+            from typing import List
+            from icontract import ensure, snapshot
+
+            def some_len(lst: List[int]) -> int:
+                return len(lst)
+
+            @snapshot(lambda lst: lst[:])
+            @snapshot(capture=some_len, name="len_lst")
+            @ensure(lambda OLD, lst: OLD.lst + [value] == lst)
+            def some_func(lst: List[int], value: int) -> None:
+                lst.append(value)
+            """)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = pathlib.Path(tmp)
+
+            pth = tmp_path / "some_module.py"
+            pth.write_text(text)
+
+            with tests.common.sys_path_with(tmp_path):
+                errors = icontract_lint.check_file(path=pth)
+                self.assertListEqual([], errors)
+
+    def test_invalid_arg(self):
+        text = textwrap.dedent("""\
+            from typing import List
+            from icontract import ensure, snapshot
+
+            def some_len(another_lst: List[int]) -> int:
+                return len(another_lst)
+
+            @snapshot(lambda another_lst: another_lst[:])  # inconsistent with some_func
+            @snapshot(some_len)  # inconsistent with some_func
+            @ensure(lambda OLD, lst: OLD.lst + [value] == lst)
+            def some_func(lst: List[int], value: int) -> None:
+                lst.append(value)
+            """)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = pathlib.Path(tmp)
+
+            pth = tmp_path / "some_module.py"
+            pth.write_text(text)
+
+            with tests.common.sys_path_with(tmp_path):
+                errors = icontract_lint.check_file(path=pth)
+                self.assertEqual(2, len(errors))
+
+                for err, lineno in zip(errors, [7, 8]):
+                    self.assertDictEqual(
+                        {
+                            'identifier': 'snapshot-invalid-arg',
+                            'description': 'Snapshot argument is missing in the function signature: another_lst',
+                            'filename': str(pth),
+                            'lineno': lineno
+                        }, err.as_mapping())
+
+    def test_without_post(self):
+        text = textwrap.dedent("""\
+            from typing import List
+            from icontract import ensure, snapshot
+
+            @snapshot(lambda lst: lst[:])  # no postcondition defined after the snapshot 
+            def some_func(lst: List[int], value: int) -> None:
+                lst.append(value)
+            """)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = pathlib.Path(tmp)
+
+            pth = tmp_path / "some_module.py"
+            pth.write_text(text)
+
+            with tests.common.sys_path_with(tmp_path):
+                errors = icontract_lint.check_file(path=pth)
+                self.assertEqual(1, len(errors))
+
+                for err, lineno in zip(errors, [4]):
+                    self.assertDictEqual({
+                        'identifier': 'snapshot-wo-post',
+                        'description': 'Snapshot defined on a function without a postcondition',
+                        'filename': str(pth),
+                        'lineno': lineno
+                    }, err.as_mapping())
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
The current structure of unit tests became too chaotic as more unit
tests need to be added in the future. This patch groups some of the
tests by the corresponding decorator to make categorization of new tests
a bit easier.