### PR TITLE
Fixed detection of snapshots without capture

### DIFF
--- a/icontract_lint/__init__.py
+++ b/icontract_lint/__init__.py
@@ -275,13 +275,16 @@ class _LintVisitor(_AstroidVisitor):
         """
         # Find the ``capture=...`` node
         capture_node = None  # type: Optional[astroid.node_classes.NodeNG]
-        if node.args:
+
+        if node.args and len(node.args) >= 1:
             capture_node = node.args[0]
-        elif node.keywords:
+
+        if capture_node is None and node.keywords:
             for keyword_node in node.keywords:
                 if keyword_node.arg == "capture":
                     capture_node = keyword_node.value
-        else:
+
+        if capture_node is None:
             self.errors.append(
                 Error(
                     identifier=ErrorID.SNAPSHOT_WO_CAPTURE,


### PR DESCRIPTION
Due to a logical error in how arguments of a snapshot were resolved, it
slipped through that we had an invalid execution path where missing
capture function was not detected.

This patch fixes the issue and adds a unit test to avoid regression.