### PR TITLE
Added support for astroid ≥ 2.6.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,12 @@ setup(
     license='License :: OSI Approved :: MIT License',
     keywords='design-by-contract precondition postcondition validation lint',
     packages=find_packages(exclude=['tests']),
-    install_requires=['icontract>=2.0.0,<3', 'astroid>=2.4.2,<3'],
+    install_requires=[
+        # yapf: disable
+        'icontract>=2.0.0,<3',
+        'astroid>=2.4.2,<3'
+        # yapf: enable
+    ],
     extras_require={
         'dev': [
             # yapf: disable


### PR DESCRIPTION
The code in astroid underwent a minor refactoring and broke the public
interface (`ALL_NODE_CLASSES` were moved to `astroid.nodes` module).
This had repercussions on pyicontract-lint since an assertion depends on
it.

This patch examines the version of astroid and adapts the assertion
according to the version so that both older and newer versions of
astroid are supported.

Fixes #37.