### PR TITLE
Updated CI badge in Readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,9 @@
 pyicontract-lint
 ================
-.. image:: https://travis-ci.com/Parquery/pyicontract-lint.svg?branch=master
-    :target: https://travis-ci.com/Parquery/pyicontract-lint
-    :alt: Build status
+
+.. image:: https://github.com/Parquery/pyicontract-lint/actions/workflows/ci.yml/badge.svg
+    :target: https://github.com/Parquery/pyicontract-lint/actions/workflows/ci.yml
+    :alt: Continuous integration
 
 .. image:: https://coveralls.io/repos/github/Parquery/pyicontract-lint/badge.svg?branch=master
     :target: https://coveralls.io/github/Parquery/pyicontract-lint


### PR DESCRIPTION
We moved our continuous integration to GitHub (see #39). This patch
updates the badge corresponding to the status of the checks in the
readme.