### PR TITLE
Released 2.1.3

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,19 +1,27 @@
+2.1.3
+=====
+* Added support for astroid ≥ 2.6.0 (#38)
+* Dropped support for Python 3.5 (#40)
+* Upgraded mypy to 0.910 and pylint to 2.9.2 (#42)
+
+  This patch also includes introduction of ``Final`` and ``TypedDict`` for more precise type annotations.
+
 2.1.2
 =====
 *  Fixed to accept snapshots with multiple args (#35)
 
 2.1.1
 =====
-* Started ignoring Astroid inference errors in decorators.
+* Started ignoring Astroid inference errors in decorators (#28)
 
   This is critical so that files can be processed even though Astroid
   fails to correctly infer all the decorators.
 
 2.1.0
 =====
-* Made handling of paths platform-dependent
-* Introduced graceful handling of read and parse failures
-* Added output on no errors if verbose
+* Made handling of paths platform-dependent (#22)
+* Introduced graceful handling of read and parse failures (#24)
+* Added output on no errors if verbose (#25)
 
 2.0.1
 =====

--- a/pyicontract_lint_meta.py
+++ b/pyicontract_lint_meta.py
@@ -3,7 +3,7 @@
 __title__ = 'pyicontract-lint'
 __description__ = 'Lint contracts defined with icontract library.'
 __url__ = 'https://github.com/Parquery/pyicontract-lint'
-__version__ = '2.1.2'
+__version__ = '2.1.3'
 __author__ = 'Marko Ristin'
 __author_email__ = 'marko.ristin@gmail.com'
 __license__ = 'MIT'


### PR DESCRIPTION
* Added support for astroid ≥ 2.6.0 (#38)
* Dropped support for Python 3.5 (#40)
* Upgraded mypy to 0.910 and pylint to 2.9.2 (#42)

  This patch also includes introduction of `Final` and `TypedDict` for more precise type annotations.